### PR TITLE
`FilePathLocator` Now Detects All Tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "dhii/simple-test-abstract": "dev-master"
+        "dhii/simple-test-abstract": "^0.1.1"
     },
     "require-dev": {
         "dhii/php-cs-fixer-config": "dev-php-5.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,27 +4,27 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "b96d14a95ddfbc44fdfc4851c5e3f3df",
-    "content-hash": "29cd5437ffc66efe81ff2c5b9cd18d97",
+    "hash": "e10c7221e0b7732352cb127cb9ca262c",
+    "content-hash": "04f82a5dd9127686ebd9c606a8bb5544",
     "packages": [
         {
             "name": "dhii/collections-abstract",
-            "version": "dev-master",
+            "version": "v0.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dhii/collections-abstract.git",
-                "reference": "153e40dab2d8344ba32c1e907bf2cd50936535cd"
+                "reference": "7c9141202af4d83b31e75efcbf481fa1cb588ad8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dhii/collections-abstract/zipball/153e40dab2d8344ba32c1e907bf2cd50936535cd",
-                "reference": "153e40dab2d8344ba32c1e907bf2cd50936535cd",
+                "url": "https://api.github.com/repos/Dhii/collections-abstract/zipball/7c9141202af4d83b31e75efcbf481fa1cb588ad8",
+                "reference": "7c9141202af4d83b31e75efcbf481fa1cb588ad8",
                 "shasum": ""
             },
             "require": {
-                "dhii/collections-abstract-base": "dev-master",
-                "dhii/collections-interface": "dev-master",
-                "dhii/stats-abstract": "dev-master"
+                "dhii/collections-abstract-base": "^0.1.0",
+                "dhii/collections-interface": "^0.1.1",
+                "dhii/stats-abstract": "^0.1.0"
             },
             "require-dev": {
                 "dhii/php-cs-fixer-config": "dev-php-5.3",
@@ -48,24 +48,24 @@
                 }
             ],
             "description": "A collections library",
-            "time": "2016-10-12 17:47:09"
+            "time": "2016-11-10 19:29:24"
         },
         {
             "name": "dhii/collections-abstract-base",
-            "version": "dev-master",
+            "version": "v0.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dhii/collections-abstract-base.git",
-                "reference": "699430c5bd24f0bd5a886ac77484a5271f6a6527"
+                "reference": "0ec0147451a72a13fb327ac6ff747c5e953c56f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dhii/collections-abstract-base/zipball/699430c5bd24f0bd5a886ac77484a5271f6a6527",
-                "reference": "699430c5bd24f0bd5a886ac77484a5271f6a6527",
+                "url": "https://api.github.com/repos/Dhii/collections-abstract-base/zipball/0ec0147451a72a13fb327ac6ff747c5e953c56f3",
+                "reference": "0ec0147451a72a13fb327ac6ff747c5e953c56f3",
                 "shasum": ""
             },
             "require": {
-                "dhii/collections-interface": "dev-master"
+                "dhii/collections-interface": "^0.1.1"
             },
             "require-dev": {
                 "codeclimate/php-test-reporter": "dev-master",
@@ -90,20 +90,20 @@
                 }
             ],
             "description": "Collection base classes that do not depend on other non-collection packages, on which there is a dependency of other collection packages that depend on this package. This is done to avoid circular reference in the collection toolchain",
-            "time": "2016-10-11 19:04:21"
+            "time": "2016-11-10 15:09:37"
         },
         {
             "name": "dhii/collections-interface",
-            "version": "dev-master",
+            "version": "v0.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dhii/collections-interface.git",
-                "reference": "65a5fd89ec5605fa57d2feb3e9cee885887f0313"
+                "reference": "1d8c785cdf8b63334b35f9a2d663b82e56d06e4f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dhii/collections-interface/zipball/65a5fd89ec5605fa57d2feb3e9cee885887f0313",
-                "reference": "65a5fd89ec5605fa57d2feb3e9cee885887f0313",
+                "url": "https://api.github.com/repos/Dhii/collections-interface/zipball/1d8c785cdf8b63334b35f9a2d663b82e56d06e4f",
+                "reference": "1d8c785cdf8b63334b35f9a2d663b82e56d06e4f",
                 "shasum": ""
             },
             "require": {
@@ -131,26 +131,26 @@
                 }
             ],
             "description": "Interfaces for collections",
-            "time": "2016-10-11 18:00:09"
+            "time": "2016-11-09 19:23:28"
         },
         {
             "name": "dhii/simple-test-abstract",
-            "version": "dev-master",
+            "version": "v0.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dhii/simple-test-abstract.git",
-                "reference": "97ab4c5a1c828b14cafa9e11abb52390df2a4c3c"
+                "reference": "7527a83af9fb7553e751d0e12c52fd4c6ef49629"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dhii/simple-test-abstract/zipball/97ab4c5a1c828b14cafa9e11abb52390df2a4c3c",
-                "reference": "97ab4c5a1c828b14cafa9e11abb52390df2a4c3c",
+                "url": "https://api.github.com/repos/Dhii/simple-test-abstract/zipball/7527a83af9fb7553e751d0e12c52fd4c6ef49629",
+                "reference": "7527a83af9fb7553e751d0e12c52fd4c6ef49629",
                 "shasum": ""
             },
             "require": {
-                "dhii/collections-abstract": "dev-master",
-                "dhii/simple-test-interface": "dev-master",
-                "dhii/stats-abstract": "dev-master",
+                "dhii/collections-abstract": "^0.1.0",
+                "dhii/simple-test-interface": "^0.1.0",
+                "dhii/stats-abstract": "^0.1.0",
                 "php": "^5.3.3 | ^7.0"
             },
             "require-dev": {
@@ -176,21 +176,24 @@
                 }
             ],
             "description": "Base classes for SimpleTest",
-            "time": "2016-10-12 18:19:39"
+            "time": "2016-11-15 16:49:04"
         },
         {
             "name": "dhii/simple-test-interface",
-            "version": "dev-master",
+            "version": "v0.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dhii/simple-test-interface.git",
-                "reference": "63d98dd026999a97eab9e9f7c56a7f0903aa2691"
+                "reference": "2a36c488250bddc668addddea9c26b6a3d446843"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dhii/simple-test-interface/zipball/63d98dd026999a97eab9e9f7c56a7f0903aa2691",
-                "reference": "63d98dd026999a97eab9e9f7c56a7f0903aa2691",
+                "url": "https://api.github.com/repos/Dhii/simple-test-interface/zipball/2a36c488250bddc668addddea9c26b6a3d446843",
+                "reference": "2a36c488250bddc668addddea9c26b6a3d446843",
                 "shasum": ""
+            },
+            "require": {
+                "php": "^5.3 | ^7.0"
             },
             "require-dev": {
                 "dhii/php-cs-fixer-config": "dev-php-5.3",
@@ -214,25 +217,25 @@
                 }
             ],
             "description": "Interfaces for Dhii SimpleTest",
-            "time": "2016-09-15 16:05:09"
+            "time": "2016-11-10 20:08:25"
         },
         {
             "name": "dhii/stats-abstract",
-            "version": "dev-master",
+            "version": "v0.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dhii/stats-abstract.git",
-                "reference": "29bf0da6147bbb87bc5fdc9f7027b979678c9e68"
+                "reference": "71f6702c3257c71ab3917b6d076d3c3588cc9f49"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dhii/stats-abstract/zipball/29bf0da6147bbb87bc5fdc9f7027b979678c9e68",
-                "reference": "29bf0da6147bbb87bc5fdc9f7027b979678c9e68",
+                "url": "https://api.github.com/repos/Dhii/stats-abstract/zipball/71f6702c3257c71ab3917b6d076d3c3588cc9f49",
+                "reference": "71f6702c3257c71ab3917b6d076d3c3588cc9f49",
                 "shasum": ""
             },
             "require": {
-                "dhii/collections-abstract-base": "dev-master",
-                "dhii/stats-interface": "dev-master"
+                "dhii/collections-abstract-base": "^0.1.0",
+                "dhii/stats-interface": "^0.1.0"
             },
             "require-dev": {
                 "dhii/php-cs-fixer-config": "dev-php-5.3",
@@ -256,24 +259,27 @@
                 }
             ],
             "description": "Abstract base for stats",
-            "time": "2016-10-12 07:11:09"
+            "time": "2016-11-10 18:55:43"
         },
         {
             "name": "dhii/stats-interface",
-            "version": "dev-master",
+            "version": "v0.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dhii/stats-interface.git",
-                "reference": "afb71a15096e9857e78d6a85d317f3e7a1dc350f"
+                "reference": "36d09a8b8a3b8058214dae6eefb8ecdd98e0f0ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dhii/stats-interface/zipball/afb71a15096e9857e78d6a85d317f3e7a1dc350f",
-                "reference": "afb71a15096e9857e78d6a85d317f3e7a1dc350f",
+                "url": "https://api.github.com/repos/Dhii/stats-interface/zipball/36d09a8b8a3b8058214dae6eefb8ecdd98e0f0ba",
+                "reference": "36d09a8b8a3b8058214dae6eefb8ecdd98e0f0ba",
                 "shasum": ""
             },
+            "require": {
+                "php": "^5.3 | ^7.0"
+            },
             "require-dev": {
-                "dhii/php-cs-fixer-config": "dev-master"
+                "dhii/php-cs-fixer-config": "dev-php-5.3"
             },
             "type": "library",
             "autoload": {
@@ -292,7 +298,7 @@
                 }
             ],
             "description": "Interfaces for stats",
-            "time": "2016-09-02 14:58:12"
+            "time": "2016-11-10 15:38:37"
         }
     ],
     "packages-dev": [
@@ -2251,7 +2257,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "dhii/simple-test-abstract": 20,
         "dhii/php-cs-fixer-config": 20,
         "codeclimate/php-test-reporter": 20
     },

--- a/test/functional/Tester/Locator/FilePathLocatorTest.php
+++ b/test/functional/Tester/Locator/FilePathLocatorTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Dhii\SimpleTest\FuncTest\Tester\Locator;
+
+/**
+ * Tests {@see Dhii\SimpleTest\Locator\FilePathLocator}
+ *
+ * @since [*next-version*]
+ */
+class FilePathLocatorTest extends \Xpmock\TestCase
+{
+    /**
+     * Creates a new instance of the test subject.
+     *
+     * @since [*next-version*]
+     *
+     * @return \Dhii\SimpleTest\Locator\FilePathLocator
+     */
+    public function createSubject()
+    {
+        $mock = $this->mock('Dhii\\SimpleTest\\Locator\\FilePathLocator')
+                ->new();
+
+        return $mock;
+    }
+
+    /**
+     * Tests whether a valid instance of the test subject can be created.
+     *
+     * @since [*next-version*]
+     */
+    public function testCanBeCreated()
+    {
+        $subject = $this->createSubject();
+
+        $this->assertInstanceOf('Dhii\\SimpleTest\\Locator\\FilePathLocatorInterface', $subject, 'Subject is not a valid file path locator');
+    }
+
+    /**
+     * Tests whether the correct tests will be located in multiple files.
+     *
+     * @since [*next-version*]
+     */
+    public function testLocate()
+    {
+        $subject = $this->createSubject();
+
+        // The 'stub' directory
+        $testsRoot = dirname(dirname(dirname(__DIR__))) . '/stub';
+        $subject->addPath(new \RecursiveDirectoryIterator($testsRoot));
+
+        $tests = iterator_to_array($subject->locate());
+        $this->assertCount(12, $tests, 'Subject failed to locate correct number of tests');
+    }
+}


### PR DESCRIPTION
Class locator now honours and exposes test keys, preventing unrelated tests from overwriting each other. This causes the `FilePathLocator` to correctly return all tests from files, addressing #3.